### PR TITLE
⏰ Increase Trivy's timeout from 5 to 10 minutes

### DIFF
--- a/.github/workflows/shared-release-container.yml
+++ b/.github/workflows/shared-release-container.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Clean Actions Runner
+        id: clean_actions_runner
+        uses: ministryofjustice/github-actions/clean-actions-runner@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        with:
+          confirm: true
+
       - name: Prepare Environment
         id: prepare_environment
         run: |

--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Clean Actions Runner
+        id: clean_actions_runner
+        uses: ministryofjustice/github-actions/clean-actions-runner@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+        with:
+          confirm: true
+
       - name: Generate .trivyignore
         id: generate_trivyignore
         shell: bash
@@ -58,7 +64,7 @@ jobs:
         with:
           image-ref: ${{ github.repository }}:${{ github.sha }}
           severity: HIGH,CRITICAL
-          timeout: ${{ input.trivy_timeout }}
+          timeout: ${{ inputs.trivy_timeout }}
           exit-code: 1
 
       - name: Comment on Scan Success

--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -5,6 +5,10 @@ on:
       runtime:
         type: string
         required: true
+      trivy_timeout:
+        type: string
+        required: false
+        default: '10m0s'
 
 permissions: {}
 
@@ -54,6 +58,7 @@ jobs:
         with:
           image-ref: ${{ github.repository }}:${{ github.sha }}
           severity: HIGH,CRITICAL
+          timeout: ${{ input.trivy_timeout }}
           exit-code: 1
 
       - name: Comment on Scan Success

--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -8,7 +8,7 @@ on:
       trivy_timeout:
         type: string
         required: false
-        default: '10m0s'
+        default: "10m0s"
 
 permissions: {}
 


### PR DESCRIPTION
This pull request:

- Adds `trivy_timeout` as an input
- Increases Trivy's timeout from 5m0s (default) to 10m0s
- Add `ministryofjustice/github-actions/clean-actions-runner` to scanning workflow

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 