### PR TITLE
🙉 Ignore unfixed vulnerabilities and OS in SCA

### DIFF
--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -65,6 +65,7 @@ jobs:
           image-ref: ${{ github.repository }}:${{ github.sha }}
           severity: HIGH,CRITICAL
           ignore-unfixed: true
+          vuln-types: library
           timeout: ${{ inputs.trivy_timeout }}
           exit-code: 1
 

--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           image-ref: ${{ github.repository }}:${{ github.sha }}
           severity: HIGH,CRITICAL
+          ignore-unfixed: true
           timeout: ${{ inputs.trivy_timeout }}
           exit-code: 1
 


### PR DESCRIPTION
This pull request:

- Sets `ignore-unfixed` to `true` so we do not alert on CVEs that don't have a fix, so are just noise
- Sets `vuln-types` to `library`, removing `os` so that users aren't burdened with OS issues

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 