### PR TITLE
🔥 Remove `github.repository` from pull request builds

### DIFF
--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           context: .
           push: false
-          tags: ${{ github.repository }}:${{ github.sha }}
+          tags: ${{ github.sha }}
 
       - name: Scan
         id: scan
@@ -62,7 +62,7 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
-          image-ref: ${{ github.repository }}:${{ github.sha }}
+          image-ref: ${{ github.sha }}
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           vuln-type: library

--- a/.github/workflows/shared-test-container.yml
+++ b/.github/workflows/shared-test-container.yml
@@ -32,13 +32,13 @@ jobs:
         with:
           context: .
           push: false
-          tags: ${{ github.repository }}:${{ github.sha }}
+          tags: ${{ github.sha }}
 
       - name: Test
         id: test
         shell: bash
         run: |
-          container-structure-test test --config container-structure-test.yml --image ${{ github.repository }}:${{ github.sha }}
+          container-structure-test test --config container-structure-test.yml --image ${{ github.sha }}
 
       - name: Comment on Test Success
         id: comment_on_test_success


### PR DESCRIPTION
## Proposed Changes

- Removes `github.repository` because if it includes uppercase characters, it will fail ([source](https://github.com/moj-analytical-services/CourtCaseLoad/actions/runs/14130001159/job/39587667249))

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>