### PR TITLE
🏗️ Add `MOJAP_IMAGE_VERSION` build arg

### DIFF
--- a/.github/workflows/shared-release-container.yml
+++ b/.github/workflows/shared-release-container.yml
@@ -85,7 +85,7 @@ jobs:
           push: true
           tags: ${{ steps.ecr_login.outputs.registry }}/${{ env.ECR_REPOSITORY_NAME }}:${{ github.ref_name }}
           build-args: |
-            MOJAP_IMAGE_VERSION: ${{ github.ref_name }}
+            MOJAP_IMAGE_VERSION=${{ github.ref_name }}
 
       - name: Sign
         id: sign


### PR DESCRIPTION
## Proposed Changes

- Adds a build arg `MOJAP_IMAGE_VERSION` which is common in many DAGs

## Testing

release workflow tested 
 - https://github.com/moj-analytical-services/analytical-platform-airflow-python-example/actions/runs/16030122544

airflow workflow tested:

 - https://airflow.compute.development.analytical-platform.service.justice.gov.uk/dags/analytical-platform.example/grid?dag_run_id=manual__2025-07-02T16%3A40%3A27%2B00%3A00&task_id=main&tab=logs

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>