### PR TITLE
⬆️ Bump GitHub Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,4 +17,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-codeql-analysis.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-codeql-analysis.yml@31245f6d7852ff4fbb735ec759cf42d182f5836e # v5.0.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@31245f6d7852ff4fbb735ec759cf42d182f5836e # v5.0.0

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -17,4 +17,4 @@ jobs:
       contents: read
       id-token: write
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-openssf-scorecard.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-openssf-scorecard.yml@31245f6d7852ff4fbb735ec759cf42d182f5836e # v5.0.0

--- a/.github/workflows/shared-dependency-review.yml
+++ b/.github/workflows/shared-dependency-review.yml
@@ -17,6 +17,6 @@ jobs:
           persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
+        uses: actions/dependency-review-action@bc41886e18ea39df68b1b1245f4184881938e050 # v4.7.2
         with:
           fail-on-severity: critical

--- a/.github/workflows/shared-release-container.yml
+++ b/.github/workflows/shared-release-container.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Octo STS
         id: octo_sts
-        uses: ministryofjustice/analytical-platform-github-actions/octo-sts@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+        uses: ministryofjustice/analytical-platform-github-actions/octo-sts@31245f6d7852ff4fbb735ec759cf42d182f5836e # v5.0.0
 
       - name: Clean Actions Runner
         id: clean_actions_runner
-        uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+        uses: ministryofjustice/action-clean-runner@67c2dd7326ddc6fc58d5555ae9d0404173a1e8d8 # v1.0.0
         with:
           confirm: true
 

--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -28,11 +28,11 @@ jobs:
 
       - name: Octo STS
         id: octo_sts
-        uses: ministryofjustice/analytical-platform-github-actions/octo-sts@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+        uses: ministryofjustice/analytical-platform-github-actions/octo-sts@31245f6d7852ff4fbb735ec759cf42d182f5836e # v5.0.0
 
       - name: Clean Actions Runner
         id: clean_actions_runner
-        uses: ministryofjustice/analytical-platform-github-actions/clean-actions-runner@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+        uses: ministryofjustice/action-clean-runner@67c2dd7326ddc6fc58d5555ae9d0404173a1e8d8 # v1.0.0
         with:
           confirm: true
 

--- a/.github/workflows/shared-test-container.yml
+++ b/.github/workflows/shared-test-container.yml
@@ -20,11 +20,11 @@ jobs:
 
       - name: Octo STS
         id: octo_sts
-        uses: ministryofjustice/analytical-platform-github-actions/octo-sts@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+        uses: ministryofjustice/analytical-platform-github-actions/octo-sts@31245f6d7852ff4fbb735ec759cf42d182f5836e # v5.0.0
 
       - name: Set Up Container Structure Test
         id: setup_container_structure_test
-        uses: ministryofjustice/analytical-platform-github-actions/setup-container-structure-test@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+        uses: ministryofjustice/action-setup-container-structure-test@d0636fa19d04c3fc71c30ae4eb8da03be63dbd4b # v1.0.0
 
       - name: Fetch Container Structure Test
         id: fetch_container_structure_test

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       packages: read
       statuses: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@31245f6d7852ff4fbb735ec759cf42d182f5836e # v5.0.0
     with:
       super-linter-variables: |
         {

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@1c5fdfdd5d791b91c74eb04a7781b2988370113c # v4.6.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-zizmor.yml@31245f6d7852ff4fbb735ec759cf42d182f5836e # v5.0.0


### PR DESCRIPTION
## Proposed Changes

- Updates [ministryofjustice/analytical-platform-github-actions](https://github.com/ministryofjustice/analytical-platform-github-actions) to [v5.0.0](https://github.com/ministryofjustice/analytical-platform-github-actions/releases/tag/v5.0.0)
- Switches to [ministryofjustice/action-clean-runner](https://github.com/ministryofjustice/action-clean-runner)
- Switches to [ministryofjustice/action-setup-container-structure-test](https://github.com/ministryofjustice/action-setup-container-structure-test)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>