### PR TITLE
reintroduced trivy scanning

### DIFF
--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -58,9 +58,49 @@ jobs:
           push: false
           tags: ${{ github.sha }}
 
+      - name: Configure AWS Credentials
+        id: configure_aws_credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::509399598587:role/trivy-analytical-platform-airflow-container-scanning
+          role-session-name: trivy-scan
+
+      - name: Install Trivy from S3
+        id: install_trivy
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          TRIVY_ARCHIVE="trivy_0.69.3_Linux-64bit.tar.gz"
+          TRIVY_CHECKSUM_FILE="trivy_0.69.3_checksum.txt"
+          aws s3 cp "s3://mojap-common-production-artifacts/trivy/v0.69.3/${TRIVY_ARCHIVE}" "$HOME/.local/bin/${TRIVY_ARCHIVE}"
+          aws s3 cp "s3://mojap-common-production-artifacts/trivy/v0.69.3/${TRIVY_CHECKSUM_FILE}" "$HOME/.local/bin/${TRIVY_CHECKSUM_FILE}"
+
+          (cd "$HOME/.local/bin" && grep " ${TRIVY_ARCHIVE}$" "${TRIVY_CHECKSUM_FILE}" | sha256sum --check --status)
+
+          tar -xzf "$HOME/.local/bin/${TRIVY_ARCHIVE}" -C "$HOME/.local/bin" trivy
+          chmod +x "$HOME/.local/bin/trivy"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/trivy" --version
+
       - name: Scan
         id: scan
-        run: exit 0 # trivy-action step removed
+        shell: bash
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
+          TRIVY_TIMEOUT: ${{ inputs.trivy_timeout }}
+        run: |
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --vuln-type library \
+            --timeout "$TRIVY_TIMEOUT" \
+            --skip-dirs "/home/analyticalplatform/.cache/R" \
+            --skip-dirs "/usr/local/lib/R/site-library/openssl/doc" \
+            --exit-code 1 \
+            "${{ github.sha }}"
+
       - name: Comment on Scan Success
         id: comment_on_scan_success
         if: steps.scan.outcome == 'success'


### PR DESCRIPTION
This pull request updates the container scanning workflow to use a custom installation of Trivy from S3 and configures AWS credentials for access. The workflow now directly runs the Trivy scan with custom parameters, replacing the previous placeholder step.

**Container scanning workflow improvements:**

* Added a step to configure AWS credentials using the `aws-actions/configure-aws-credentials` action, enabling access to private S3 buckets for artifact retrieval.
* Introduced a step to install Trivy from an internal S3 bucket, including checksum verification for security, and added the binary to the system path.
* Replaced the placeholder scan step with a direct invocation of Trivy, specifying severity levels, timeouts, and directories to skip, and set up environment variables for Trivy database repositories.

This work is tracked in https://github.com/ministryofjustice/analytical-platform-security/issues/28

Tested in python example repo:

<img width="394" height="349" alt="Screenshot 2026-04-23 at 08 58 49" src="https://github.com/user-attachments/assets/4966c9ab-52d8-4c96-827d-286363a90f3e" />
