### PR TITLE
🛂 Add GitHub Actions permissions to container scanning workflow

### DIFF
--- a/.github/workflows/shared-scan-container.yml
+++ b/.github/workflows/shared-scan-container.yml
@@ -16,6 +16,7 @@ jobs:
   scan-container:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       id-token: write
       pull-requests: write


### PR DESCRIPTION
Fixes https://github.com/ministryofjustice/data-platform/issues/451

## Proposed Changes

- Adds `actions: read`

Tested here https://github.com/ministryofjustice/coat-copilot-usage-pipeline/pull/1

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>