### PR TITLE
default SARIF rules to [] to aviod jq null error on clean scans

### DIFF
--- a/.github/workflows/shared-scheduled-container-scan.yml
+++ b/.github/workflows/shared-scheduled-container-scan.yml
@@ -129,7 +129,7 @@ jobs:
           # The finding message text is rewritten to match the classified severity so the output is consistent.
 
           RULE_SEVERITIES=$(echo "${SARIF}" | jq -c '
-            .runs[0].tool.driver.rules
+            (.runs[0].tool.driver.rules // [])
             | map({key: .id, value: (.properties["security-severity"] // "0" | tonumber)})
             | from_entries
           ')
@@ -169,7 +169,7 @@ jobs:
 
                   # 1. Build $fix_versions map: scans each rule'\''s help.text for a "Fix Version:" line and maps ruleId → first fix version
 
-                  (.runs[0].tool.driver.rules
+                  (.runs[0].tool.driver.rules // []
                     | map({
                         key: .id,
                         value: (


### PR DESCRIPTION
Grype omits `tool.driver.rules` from the SARIF output entirely when a scan finds no results, causing `jq`'s `map` to fail with "Cannot iterate over null (null)" and abort the job before it could report a clean scan.

Default `.runs[0].tool.driver.rules` to `[]` when absent.